### PR TITLE
Add basic Next.js note taking app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+.env
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# nextnote
+# NextNote
+
+A simple note-taking application built with Next.js.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+Build for production:
+
+```bash
+npm run build
+```
+
+This project stores notes in `localStorage` so they persist between sessions in the same browser.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nextnote",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react';
+
+export default function Home() {
+  const [notes, setNotes] = useState([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const saved = window.localStorage.getItem('notes');
+      if (saved) {
+        try {
+          setNotes(JSON.parse(saved));
+        } catch (e) {
+          console.error('Failed to parse notes', e);
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('notes', JSON.stringify(notes));
+    }
+  }, [notes]);
+
+  const addNote = () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setNotes([...notes, { id: Date.now(), text: trimmed }]);
+    setText('');
+  };
+
+  const deleteNote = (id) => {
+    setNotes(notes.filter((note) => note.id !== id));
+  };
+
+  return (
+    <main style={{ maxWidth: 600, margin: '0 auto', padding: '2rem' }}>
+      <h1>NextNote</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <textarea
+          style={{ width: '100%', height: '100px' }}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Write your note here"
+        />
+        <button onClick={addNote} style={{ marginTop: '0.5rem' }}>
+          Add Note
+        </button>
+      </div>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {notes.map((note) => (
+          <li key={note.id} style={{ marginBottom: '0.5rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span>{note.text}</span>
+              <button onClick={() => deleteNote(note.id)}>Delete</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js note-taking app storing notes in browser localStorage
- add project metadata, scripts, and dependencies
- document development workflow and ignore build artifacts

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4c44cc808332a0233445aff5f850