### PR TITLE
feat: mobile-first responsive UI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import Sidebar from '../components/Sidebar';
 import Navbar from '../components/Navbar';
+import FAB from '../components/FAB';
 import type { ReactNode } from 'react';
 
 export const metadata = {
@@ -15,8 +16,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Sidebar />
         <div className="flex flex-1 flex-col">
           <Navbar />
-          <main className="flex-1 p-4 overflow-y-auto">{children}</main>
+          <main className="flex-1 p-4 pb-24 md:pb-4 overflow-y-auto">{children}</main>
         </div>
+        <FAB />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,18 +17,10 @@ const mockNotes = [
 
 export default function Home() {
   return (
-    <div className="relative">
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {mockNotes.map((note) => (
-          <NoteCard key={note.id} {...note} />
-        ))}
-      </div>
-      <a
-        href="/note/new"
-        className="fixed bottom-6 right-6 w-14 h-14 rounded-full bg-blue-600 text-white flex items-center justify-center text-3xl shadow-lg hover:bg-blue-700"
-      >
-        +
-      </a>
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {mockNotes.map((note) => (
+        <NoteCard key={note.id} {...note} />
+      ))}
     </div>
   );
 }

--- a/components/FAB.tsx
+++ b/components/FAB.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function FAB() {
+  return (
+    <Link
+      href="/note/new"
+      aria-label="Create new note"
+      className="md:hidden fixed bottom-20 right-4 z-40 w-14 h-14 rounded-full bg-blue-600 text-white flex items-center justify-center text-3xl shadow-lg hover:bg-blue-700"
+    >
+      +
+    </Link>
+  );
+}
+

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,23 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
 import ThemeToggle from './ThemeToggle';
+import { navLinks } from './Sidebar';
 
 export default function Navbar() {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
-    <header className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
-      <div className="flex items-center space-x-2">
-        <h1 className="font-semibold text-lg sm:hidden">NextNote</h1>
-        <div className="relative">
-          <input
-            type="text"
-            placeholder="Search..."
-            className="pl-10 pr-4 py-2 rounded-md bg-gray-100 dark:bg-gray-700 placeholder-gray-500 focus:outline-none"
-          />
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">🔍</span>
+    <header className="sticky top-0 z-40 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+      <div className="flex items-center justify-between h-14 md:h-16 px-4">
+        <div className="flex items-center gap-2">
+          <button
+            aria-label="Open menu"
+            className="md:hidden h-11 w-11 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
+            onClick={() => setMenuOpen(true)}
+          >
+            ☰
+          </button>
+          <Link href="/" className="font-semibold text-lg">
+            NextNote
+          </Link>
+        </div>
+
+        <div className="hidden md:block flex-1 max-w-md mx-4">
+          <div className="relative">
+            <input
+              type="text"
+              placeholder="Search..."
+              className="w-full pl-10 pr-4 py-2 rounded-md bg-gray-100 dark:bg-gray-700 placeholder-gray-500 focus:outline-none"
+            />
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">🔍</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            aria-label="Search"
+            className="md:hidden h-11 w-11 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
+            onClick={() => setSearchOpen(true)}
+          >
+            🔍
+          </button>
+          <Link
+            href="/note/new"
+            className="hidden md:inline-flex px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            + New Note
+          </Link>
+          <div className="hidden md:block">
+            <ThemeToggle />
+          </div>
+          <div className="w-10 h-10 rounded-full bg-gray-300" />
         </div>
       </div>
-      <div className="flex items-center space-x-3">
-        <ThemeToggle />
-        <div className="w-8 h-8 rounded-full bg-gray-300" />
-      </div>
+
+      {/* Mobile menu drawer */}
+      {menuOpen && (
+        <div
+          className="md:hidden fixed inset-0 z-50 bg-black/50"
+          onClick={() => setMenuOpen(false)}
+        >
+          <nav
+            className="absolute left-0 top-0 bottom-0 w-64 bg-white dark:bg-gray-800 p-4 space-y-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="block rounded-md px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                onClick={() => setMenuOpen(false)}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      )}
+
+      {/* Mobile search overlay */}
+      {searchOpen && (
+        <div className="md:hidden fixed inset-0 z-50 bg-white dark:bg-gray-900 p-4">
+          <div className="flex items-center gap-2">
+            <input
+              autoFocus
+              type="text"
+              placeholder="Search..."
+              className="flex-1 p-2 rounded-md bg-gray-100 dark:bg-gray-800 focus:outline-none"
+            />
+            <button
+              aria-label="Close search"
+              className="h-11 w-11 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
+              onClick={() => setSearchOpen(false)}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
     </header>
   );
 }
+

--- a/components/NoteCard.tsx
+++ b/components/NoteCard.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { useState, TouchEvent } from 'react';
 
 interface NoteCardProps {
   id: string;
@@ -8,16 +11,56 @@ interface NoteCardProps {
 }
 
 export default function NoteCard({ id, title, preview, updatedAt }: NoteCardProps) {
+  const [startX, setStartX] = useState<number | null>(null);
+  const [showActions, setShowActions] = useState(false);
+
+  const handleTouchStart = (e: TouchEvent) => {
+    setStartX(e.touches[0].clientX);
+  };
+
+  const handleTouchEnd = (e: TouchEvent) => {
+    if (startX === null) return;
+    const diff = e.changedTouches[0].clientX - startX;
+    if (diff < -60) {
+      setShowActions(true);
+    } else if (diff > 60) {
+      setShowActions(false);
+    }
+    setStartX(null);
+  };
+
   return (
-    <Link
-      href={`/note/${id}`}
-      className="block p-4 rounded-lg bg-white dark:bg-gray-800 shadow hover:shadow-md transition-shadow"
-    >
-      <h3 className="font-semibold mb-1">{title}</h3>
-      <p className="text-sm text-gray-600 dark:text-gray-400 mb-2 overflow-hidden text-ellipsis">
-        {preview}
-      </p>
-      <span className="text-xs text-gray-500">{updatedAt}</span>
-    </Link>
+    <div className="relative overflow-hidden">
+      <div
+        className={`absolute inset-0 flex items-center justify-end gap-2 pr-2 bg-gray-100 dark:bg-gray-700 transition-transform ${
+          showActions ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        <button className="w-11 h-11 rounded-md bg-yellow-500 text-white" aria-label="Favorite">
+          ⭐
+        </button>
+        <button className="w-11 h-11 rounded-md bg-green-600 text-white" aria-label="Archive">
+          📦
+        </button>
+        <button className="w-11 h-11 rounded-md bg-red-600 text-white" aria-label="Delete">
+          🗑️
+        </button>
+      </div>
+      <Link
+        href={`/note/${id}`}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        className={`block p-4 rounded-lg bg-white dark:bg-gray-800 shadow hover:shadow-md transition-transform ${
+          showActions ? '-translate-x-32' : ''
+        }`}
+      >
+        <h3 className="font-semibold mb-1 text-base md:text-lg">{title}</h3>
+        <p className="text-sm md:text-base text-gray-600 dark:text-gray-400 mb-2 overflow-hidden text-ellipsis">
+          {preview}
+        </p>
+        <span className="text-xs text-gray-500">{updatedAt}</span>
+      </Link>
+    </div>
   );
 }
+

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -3,30 +3,54 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-const links = [
-  { href: '/', label: 'Notes' },
-  { href: '/favorites', label: 'Favorites' },
-  { href: '/trash', label: 'Trash' },
+export const navLinks = [
+  { href: '/', label: 'Notes', icon: '📝' },
+  { href: '/favorites', label: 'Favorites', icon: '⭐' },
+  { href: '/trash', label: 'Trash', icon: '🗑️' },
+  { href: '/settings', label: 'Settings', icon: '⚙️' },
 ];
 
 export default function Sidebar() {
   const pathname = usePathname();
+
   return (
-    <aside className="hidden sm:flex sm:w-64 flex-col border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
-      <h2 className="text-xl font-semibold mb-6">NextNote</h2>
-      <nav className="space-y-2">
-        {links.map((link) => (
+    <>
+      {/* Desktop sidebar */}
+      <aside className="hidden md:flex md:w-64 flex-col border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+        <h2 className="text-xl font-semibold mb-6">NextNote</h2>
+        <nav className="space-y-2">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`flex items-center gap-2 rounded-md px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                pathname === link.href ? 'bg-gray-100 dark:bg-gray-700 font-medium' : ''
+              }`}
+            >
+              <span>{link.icon}</span>
+              <span className="hidden lg:inline">{link.label}</span>
+            </Link>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Mobile bottom navigation */}
+      <nav className="md:hidden fixed bottom-0 inset-x-0 z-30 flex justify-around border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-2">
+        {navLinks.map((link) => (
           <Link
             key={link.href}
             href={link.href}
-            className={`block rounded-md px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 ${
-              pathname === link.href ? 'bg-gray-100 dark:bg-gray-700 font-medium' : ''
+            className={`flex flex-col items-center justify-center flex-1 h-14 text-xs ${
+              pathname === link.href ? 'text-blue-600 dark:text-blue-400' : 'text-gray-600 dark:text-gray-300'
             }`}
           >
-            {link.label}
+            <span className="text-xl" aria-hidden>
+              {link.icon}
+            </span>
+            <span className="mt-1">{link.label}</span>
           </Link>
         ))}
       </nav>
-    </aside>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- refactor layout with responsive navbar, bottom tab bar, and global FAB
- add swipe actions and adaptive typography for note cards
- adjust grid layout for mobile-first responsiveness

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden for @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5051a4888332900c22fa6dd9f757