### PR TITLE
Require authentication before saving notes

### DIFF
--- a/app/note/[id]/page.tsx
+++ b/app/note/[id]/page.tsx
@@ -2,14 +2,24 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { db } from '../../../lib/firebase';
+import { db, auth } from '../../../lib/firebase';
 import { doc, setDoc } from 'firebase/firestore';
+import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
 
 export default function NoteEditor({ params }: { params: { id: string } }) {
   const router = useRouter();
   const [content, setContent] = useState('');
 
   const handleSave = async () => {
+    if (!auth.currentUser) {
+      try {
+        await signInWithPopup(auth, new GoogleAuthProvider());
+      } catch (err) {
+        console.error('Sign-in required to save note', err);
+        alert('You must sign in to save notes');
+        return;
+      }
+    }
     const id = params.id === 'new' ? Date.now().toString() : params.id;
     const note = {
       id,

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /notes/{note} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+  }
+}

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
+import { getAuth } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyBHY6LL8TByCxL2eUEIS5QJ-gSVEWqhk',
@@ -12,3 +13,4 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- Require Firebase Auth sign-in before saving notes
- Export `auth` instance and update Firestore rules to allow writes only for signed-in users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5c3f1bec8332a6161eec612ca49a