### PR TITLE
Use existing Firebase app if available

### DIFF
--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,4 +1,4 @@
-import { initializeApp } from 'firebase/app';
+import { getApp, getApps, initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 
@@ -11,6 +11,6 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-const app = initializeApp(firebaseConfig);
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- import `getApp` and `getApps` to allow reusing an existing Firebase app
- initialize Firebase only if no app exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc60f47c8c8332ac4e6f03f384b435