### PR TITLE
Fetch notes from Firestore

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 import NoteCard from "../components/NoteCard";
+import { db } from "../lib/firebase";
+import { collection, getDocs } from "firebase/firestore";
 
 interface Note {
   id: string;
@@ -15,10 +17,27 @@ export default function Home() {
   const [notes, setNotes] = useState<Note[]>([]);
 
   useEffect(() => {
-    const stored = localStorage.getItem("notes");
-    if (stored) {
-      setNotes(JSON.parse(stored));
-    }
+    const fetchNotes = async () => {
+      try {
+        const snapshot = await getDocs(collection(db, "notes"));
+        const fetched: Note[] = snapshot.docs.map((doc) => ({
+          id: doc.id,
+          title: (doc.data().title as string) || "Untitled",
+          preview: (doc.data().preview as string) || "",
+          updatedAt: (doc.data().updatedAt as string) || "",
+          status: "saved",
+        }));
+        setNotes(fetched);
+        localStorage.setItem("notes", JSON.stringify(fetched));
+      } catch (err) {
+        console.error("Failed to fetch notes", err);
+        const stored = localStorage.getItem("notes");
+        if (stored) {
+          setNotes(JSON.parse(stored));
+        }
+      }
+    };
+    fetchNotes();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- load notes from Firestore on the home page instead of relying solely on local storage
- fall back to locally stored notes if Firestore requests fail

## Testing
- `npm test`
- `npm run build` *(fails: FirebaseError: auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5b6fe29c833280f58528c60fe3f7