### PR TITLE
Skip remote save when Appwrite config missing

### DIFF
--- a/app/note/[id]/page.tsx
+++ b/app/note/[id]/page.tsx
@@ -24,21 +24,32 @@ export default function NoteEditor({ params }: { params: { id: string } }) {
       status: 'saved' as 'saved' | 'failed',
     };
 
+    const hasAppwriteConfig =
+      process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT &&
+      process.env.NEXT_PUBLIC_APPWRITE_PROJECT &&
+      databaseId &&
+      collectionId;
+
     try {
-      if (params.id === 'new') {
-        await databases.createDocument(databaseId, collectionId, id, {
-          content,
-          title: note.title,
-          preview: note.preview,
-          updatedAt: note.updatedAt,
-        });
+      if (hasAppwriteConfig) {
+        if (params.id === 'new') {
+          await databases.createDocument(databaseId, collectionId, id, {
+            content,
+            title: note.title,
+            preview: note.preview,
+            updatedAt: note.updatedAt,
+          });
+        } else {
+          await databases.updateDocument(databaseId, collectionId, id, {
+            content,
+            title: note.title,
+            preview: note.preview,
+            updatedAt: note.updatedAt,
+          });
+        }
       } else {
-        await databases.updateDocument(databaseId, collectionId, id, {
-          content,
-          title: note.title,
-          preview: note.preview,
-          updatedAt: note.updatedAt,
-        });
+        // Appwrite isn't configured; skip remote save and rely on local storage.
+        console.warn('Appwrite configuration missing. Saving note locally only.');
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- avoid network calls when Appwrite endpoint or IDs are missing
- warn and rely on local storage if Appwrite isn't configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bce0f147f883328be54cc759b392cd