### PR TITLE
Handle Appwrite save failures and filter notes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,14 +40,16 @@ export default function Home() {
         } else {
           const stored = localStorage.getItem("notes");
           if (stored) {
-            setNotes(JSON.parse(stored));
+            const parsed: Note[] = JSON.parse(stored);
+            setNotes(parsed.filter((n) => n.status === "saved"));
           }
         }
       } catch (err) {
         console.error("Failed to fetch notes", err);
         const stored = localStorage.getItem("notes");
         if (stored) {
-          setNotes(JSON.parse(stored));
+          const parsed: Note[] = JSON.parse(stored);
+          setNotes(parsed.filter((n) => n.status === "saved"));
         }
       }
     };


### PR DESCRIPTION
## Summary
- Avoid saving notes when Appwrite configuration is missing or save fails and alert the user
- Filter local notes to only show successfully saved entries

## Testing
- `npm test`
- `npm run build` *(fails: Module not found: Can't resolve 'appwrite')*

------
https://chatgpt.com/codex/tasks/task_e_68bcf17edac08332a85e6986c37d1e0c